### PR TITLE
fix(pwa): set address bar theme color

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -52,6 +52,8 @@ export default defineNuxtConfig({
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
         { name: 'description', content: appDescription },
         { name: 'apple-mobile-web-app-status-bar-style', content: 'black-translucent' },
+        { name: 'theme-color', media: '(prefers-color-scheme: light)', content: 'white' },
+        { name: 'theme-color', media: '(prefers-color-scheme: dark)', content: '#222222'},
       ],
     },
   },


### PR DESCRIPTION
### Description

Stops Lighthouse from complaining about the `theme-color` meta tag not being set.

<img width="728" alt="image" src="https://github.com/antfu/vitesse-nuxt3/assets/95413644/d2afefac-c00b-40ff-9665-e923c5949e1e">

