### PR TITLE
fix: align docker `FromAsCasing`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine as build-stage
+FROM node:20-alpine AS build-stage
 
 WORKDIR /app
 RUN corepack enable
@@ -11,7 +11,7 @@ COPY . .
 RUN pnpm build
 
 # SSR
-FROM node:20-alpine as production-stage
+FROM node:20-alpine AS production-stage
 
 WORKDIR /app
 


### PR DESCRIPTION
https://docs.docker.com/reference/build-checks/from-as-casing/

<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This PR fixes the [FromAsCasing](https://docs.docker.com/reference/build-checks/from-as-casing/) warning.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues


### Additional context

For my projects, I have always added a docker-compose and a development stage to the dockerfile. I can do a follow-up pr if needed.

<!-- e.g. is there anything you'd like reviewers to focus on? -->
